### PR TITLE
Add environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,14 @@ services:
   name: some-name
   path: /openshift/template.yaml
   url: https://github.com/org/repo/
+  skip: True
   parameters:
     SOME_PARAM: some_value
+  environments:
+  - name: production
+    parameters:
+      SOME_PARAM: prod_value
+    skip: True
 ```
 
 * *hash*: Commit hash or branch which is used a) for downloading OpenShift template and b) to generate image tag for template processing (`master` is translated to `latest`)
@@ -39,7 +45,10 @@ services:
 * *name*: Name of the service
 * *path*: Path to the template in the repo
 * *url*: URL of the repository which contains the template
+* *skip*: False by default, if True, the service will be skipped from processing (i.e. template will not be processed and output file for service will not be produced)
 * *parameters*: An object where key is the parameter name and value is the parameter value. These parameters will be added to `oc process` when processing the template
+* *environments*: A list where you can specify multiple environments which can be selected by passing an argument `--environment`. Values in a given environment will override
+  values in the top level section. Anything can be overridden but `name`, `url` and `hash`.
 
 ## Config YAML
 

--- a/saasherder/cli.py
+++ b/saasherder/cli.py
@@ -13,6 +13,8 @@ def main():
                         help='Config file for saas herder')
     parser.add_argument('--context', default=None,
                         help='Context to use')
+    parser.add_argument('--environment', default=None,
+                        help='Environment to use to override service defined values')
     subparsers = parser.add_subparsers(dest="command")
     subparser_pull = subparsers.add_parser("pull")
     subparser_pull.add_argument('service', nargs="*", default="all")
@@ -56,7 +58,7 @@ def main():
 
     args = parser.parse_args()
 
-    se = SaasHerder(args.config, args.context)
+    se = SaasHerder(args.config, args.context, args.environment)
     if args.command == "pull":
       if args.service:
         se.collect_services(args.service, args.token)

--- a/tests/data/service/redirector.yaml
+++ b/tests/data/service/redirector.yaml
@@ -3,3 +3,14 @@ services:
   name: redirector
   path: homeless-templates/redirector.yaml
   url: https://github.com/openshiftio/saas/
+  parameters:
+    IMAGE: some_image
+  environments:
+  - name: production
+    parameters:
+      IMAGE: production_image
+  - name: test
+    skip: True
+  - name: url
+    url: some_url
+

--- a/tests/data/template/redirector.yaml
+++ b/tests/data/template/redirector.yaml
@@ -43,7 +43,7 @@ objects:
             value: https://openshift.io/
           - name: REDIRECTOR_TYPE
             value: redirect
-          image: registry.centos.org/mattermost/nginx-redirector:${IMAGE_TAG}
+          image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always
           name: redirector
           ports:
@@ -78,3 +78,5 @@ objects:
 parameters:
   - name: IMAGE_TAG 
     value: latest
+  - name: IMAGE
+    value: registry.centos.org/mattermost/nginx-redirector

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -34,4 +34,35 @@ class TestTemplating(object):
     for item in data["items"]:
       if item["kind"] == "DeploymentConfig":
         assert item["spec"]["template"]["spec"]["containers"][0]["image"].endswith(hash)
-    
+
+  def test_template_parameters(self):
+    image = "some_image"
+    se = SaasHerder(temp_path, None)
+    se.template("tag", "redirector", output_dir, local=True)
+    data = anymarkup.parse_file(os.path.join(output_dir, "redirector.yaml"))
+    for item in data["items"]:
+      if item["kind"] == "DeploymentConfig":
+        assert item["spec"]["template"]["spec"]["containers"][0]["image"].startswith(image)
+
+  def test_template_environment_parameters(self):
+    image = "production_image"
+    environment = "production"
+    se = SaasHerder(temp_path, None, environment)
+    se.template("tag", "redirector", output_dir, local=True)
+    data = anymarkup.parse_file(os.path.join(output_dir, "redirector.yaml"))
+    for item in data["items"]:
+      if item["kind"] == "DeploymentConfig":
+        assert item["spec"]["template"]["spec"]["containers"][0]["image"].startswith(image)
+
+  def test_template_environment_skip(self):
+    environment = "test"
+    output_dir = tempfile.mkdtemp()
+    se = SaasHerder(temp_path, None, environment)
+    se.template("tag", "redirector", output_dir, local=True)
+    assert not os.path.isfile(os.path.join(output_dir, "redirector.yaml"))
+
+  def test_template_environment_url(self):
+    environment = "url"
+    output_dir = tempfile.mkdtemp()
+    se = SaasHerder(temp_path, None, environment)
+    assert se.get_services("redirector")[0]["url"] != "some_url"


### PR DESCRIPTION
This is PR will help us differentiate between multiple deployment environments (stage, prod...). Although we tend to keep things as close as possible across envs, some configuration needs changes. E.g.:

* Replica count set through `parameters` might differ for prod and stage
* We might need to push new service to stage but not to prod yet (`skip:True`)
* Renaming template yaml in repo would result in a chicken egg problem where you cannot deploy to stage with old name, but at the same time cannot change to new name as that would break deployment to prod..