### PR TITLE
Improvements on changelog to be able to deliver reports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 anymarkup
 requests
+python-dateutil

--- a/saasherder/changelog.py
+++ b/saasherder/changelog.py
@@ -27,6 +27,23 @@ class ChangelogRender(object):
         self.new = new
         self.url = url
 
+    def plain(self):
+        header_template = "Context changes: {old:.7}..{new} ({url}/compare/{old}...{new})\n\n"
+
+        section_template = textwrap.dedent("""\
+                           ## {names} ({url})
+
+                           Changes: {old:.7}..{new:.7} ({url}/compare/{old}...{new})
+
+                           Last updated at {last_changed}
+
+                           {log}""")
+
+        commit_template =  '- %s\n  {url}/commit/%H'
+
+
+        return self.render(header_template, section_template, commit_template)
+
     def markdown(self):
         header_template = "Context changes: [{old:.7}..{new}]({url}/compare/{old}...{new})\n\n"
 
@@ -160,7 +177,7 @@ class Changelog(object):
 
         return self.service_run(service, "git checkout {}".format(service['new']))
 
-    def generate(self, context, old, new):
+    def generate(self, context, old, new, format):
 
         logger.info("Generating changelog for {}".format(context))
 
@@ -213,13 +230,15 @@ class Changelog(object):
 
         # Fetch all the services that changed
         for service in self.changed_services:
-            # only need to checkout the first
             self.checkout(service)
 
         url = run("git remote get-url origin").rstrip("/").rstrip(".git")
 
         render = ChangelogRender(self, old, new, url)
 
-        print render.markdown()
+        if format == "markdown":
+            print render.markdown()
+        elif format == "plain":
+            print render.plain()
 
         return 0

--- a/saasherder/changelog.py
+++ b/saasherder/changelog.py
@@ -5,11 +5,70 @@ from dateutil.parser import parse
 
 import logging
 import os
-import re
 import textwrap
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+def run(cmd):
+    logger.info("$ {}".format(cmd))
+    p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        raise Exception("$ {} FAILED with exit code {}"
+                        .format(cmd, p.returncode))
+
+    return stdout.decode('utf-8')
+
+class ChangelogRender(object):
+    def __init__(self, changelog, old, new, url):
+        self.changelog = changelog
+        self.old = old
+        self.new = new
+        self.url = url
+
+    def markdown(self):
+        """Pretty print the change log"""
+
+        # Build the body
+        header = "Context changes: [{old:.7}..{new}]({url}/compare/{old}...{new})\n\n"
+        header = header.format(url=self.url, old=self.old, new=self.new)
+
+        body = [header]
+
+        for service in self.changelog.changed_services:
+            names = ", ".join(service['names'])
+            url = service['url']
+
+            section = """\
+                      **[{names}]({url})**
+
+                      Changes: [{old:.7}..{new:.7}]({url}/compare/{old}...{new})
+
+                      Last updated at {last_changed}
+
+                      {log}"""
+
+            section = textwrap.dedent(section)
+
+            section = section.format(names=names,
+                                     url=url,
+                                     old=service['old'],
+                                     new=service['new'],
+                                     log=self.log(service),
+                                     last_changed=self.last_changed(service))
+            body.append(section)
+
+        return '\n'.join(body)
+
+    def log(self, service):
+        """Get the changelog for one service"""
+        template = '- [%h]({}/commit/%H) %s'.format(service['url'])
+        return self.changelog.service_run(service, "git log --format='{}' {}...{}".format(template, service['old'], service['new']))
+
+    def last_changed(self, service):
+        """Get the commit time for service at specific commit"""
+        return self.changelog.service_run(service, "git log -1 --format=%cd {}".format(service['new'])).strip()
 
 class Changelog(object):
 
@@ -18,8 +77,11 @@ class Changelog(object):
     def __init__(self, parent):
         self.parent = parent
 
-    @staticmethod
-    def diff(now, previous):
+        # Key: url of the service
+        # Value: list of services that have changed
+        self.changed_services = []
+
+    def fetch_diff(self, now, previous):
         """Return the difference between 2 service lists
 
         This is not a commutative relationship. We are looking for services in
@@ -31,7 +93,7 @@ class Changelog(object):
 
         # All the services that changed. We will store only those that exist in
         # now and in previous, for which 'hash' is defined in both
-        changed = []
+        changed_services = {}
         for service_name, service in now.items():
             try:
                 prev_service = previous[service_name]
@@ -42,140 +104,55 @@ class Changelog(object):
                 # or if 'hash' is not defined for either service
                 continue
 
-            if service_hash and prev_service_hash and prev_service_hash != service_hash:
-                changed.append(
-                    dict(
-                        name=service['name'],
-                        url=service['url'],
-                        new=service_hash,
-                        old=prev_service_hash
-                    )
-                )
+            if service_hash is None or prev_service_hash is None:
+                continue
 
-        return changed
+            url = service['url'].rstrip('/')
 
-    @staticmethod
-    def run(cmd):
-        logger.info("$ {}".format(cmd))
-        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
-        stdout, stderr = p.communicate()
-        if p.returncode != 0:
-            raise Exception("$ {} FAILED with exit code {}"
-                            .format(cmd, p.returncode))
+            if prev_service_hash != service_hash:
+                if url in changed_services:
+                    changed_services[url]['names'].append(service_name)
+                else:
+                    diff_item = dict(name=service_name,
+                                     names=[service_name],
+                                     url=url,
+                                     new=service_hash,
+                                     old=prev_service_hash)
 
-        return stdout.decode('utf-8')
+                    changed_services[url] = diff_item
 
-    def worktree(self, service_name):
+        self.changed_services = changed_services.values()
+        return self.changed_services
+
+    def worktree(self, service):
         """Get git worktree path for a service"""
+        return self.workspace + service['name']
 
-        return self.workspace + service_name
+    def service_run(self, service, cmd):
+        """Run in the directory of the service"""
+        return run("cd {} && {}".format(self.worktree(service), cmd))
 
     def _clone(self, service):
         """Private; use checkout instead"""
-
-        cmd = "git clone {} {}".format(service['url'],
-                                       self.worktree(service['name']))
-        self.run(cmd)
+        run("git clone {} {}".format(service['url'], self.worktree(service)))
 
     def _fetch(self, service):
         """Private; use checkout instead"""
-
-        worktree = self.worktree(service['name'])
-        cmd = "cd {} && git fetch ".format(worktree)
-
-        return self.run(cmd)
+        self.service_run(service, "git fetch")
 
     def checkout(self, service):
         """Get a service checked out at specified version"""
 
-        name = service['name']
-        version = service['new']
+        service_name = service['name']
 
-        if os.path.exists(self.worktree(name)):
-            logger.info("Found git worktree for {}; updating".format(name))
+        if os.path.exists(self.worktree(service)):
+            logger.info("Found git worktree for {}; updating".format(service_name))
             self._fetch(service)
         else:
-            logger.info("Cloning git worktree for {}".format(name))
+            logger.info("Cloning git worktree for {}".format(service_name))
             self._clone(service)
 
-        worktree = self.worktree(service['name'])
-        cmd = "cd {} && git checkout {} ".format(worktree, version)
-
-        return self.run(cmd)
-
-    def log(self, service, old, new):
-        """Get the changelog for one service"""
-
-        worktree = self.worktree(service['name'])
-        remote = service['url'].strip('/')
-        template = '- [%h](_REMOTE_/commit/%H) %s'
-
-        cmd = ("cd {} && git log --format='{}' {}...{}"
-               .format(worktree, template, old, new))
-
-        return self.run(cmd).replace('_REMOTE_', remote)
-
-    def last_changed(self, service, commit):
-        """Get the commit time for service at specific commit"""
-
-        worktree = self.worktree(service['name'])
-        cmd = "cd {} && git log -1 --format=%cd {}".format(worktree, commit)
-
-        return self.run(cmd).strip()
-
-    @staticmethod
-    def markdown(changelog, old, new, context_url):
-        """Pretty print the change log
-
-        The incoming object is a list of `(name, timestamp, messages)` tuples.
-        """
-
-        # Some services may come from the same URL, in this case let's
-        # deduplicate them
-        dedup_changelog = {}
-        for service, timestamp, messages in changelog:
-            url = service['url']
-            name = service.pop('name', None)
-            if url not in dedup_changelog:
-                dedup_changelog[url] = dict(
-                    name=[name],
-                    service=service,
-                    timestamp=timestamp,
-                    messages=messages
-                )
-            else:
-                dedup_changelog[url]['name'].append(name)
-
-        # Build the body
-        context_url = re.sub("\.git$", "", context_url.strip())
-
-        header = "Context changes: [{old:.7}..{new}]({url}/compare/{old}...{new})\n\n"
-        header = header.format(url=context_url, old=old, new=new)
-
-        body = [header]
-
-        for entry in dedup_changelog.values():
-            name = ", ".join(entry['name'])
-            url = re.sub("/$", "", entry['service']['url'])
-
-            section = """\
-                      **[{name}]({url})**
-
-                      Changes: [{old:.7}..{new:.7}]({url}/compare/{old}...{new})
-
-                      Last updated at {entry[timestamp]}
-
-                      {entry[messages]}"""
-
-            section = textwrap.dedent(section)
-            section = section.format(name=name,
-                                     entry=entry,
-                                     old=entry['service']['old'],
-                                     new=entry['service']['new'],
-                                     url=url)
-            body.append(section)
-
-        return '\n'.join(body)
+        return self.service_run(service, "git checkout {}".format(service['new']))
 
     def generate(self, context, old, new):
 
@@ -191,59 +168,52 @@ class Changelog(object):
         # Where am I right now?
         try:
             # This will fail for detached HEAD
-            branch = self.run("git symbolic-ref --short HEAD").strip()
+            branch = run("git symbolic-ref --short HEAD").strip()
             logger.info("On branch {} before generating changelog"
                         .format(branch))
 
         except Exception:
-            branch = self.run("git rev-parse --short HEAD").strip()
+            branch = run("git rev-parse --short HEAD").strip()
             logger.info("HEAD at {} before generating changelog"
                         .format(branch))
 
         # Resolve commit if a date was passed in 'old'
         try:
             dt_old = parse(old)
-            old = self.run("git rev-list -1 --before='{}' {}".format(dt_old, branch)).strip()
+            old = run("git rev-list -1 --before='{}' {}".format(dt_old, branch)).strip()
         except:
             pass
 
         # Resolve commit if a date was passed in 'new'
         try:
             dt_new = parse(new)
-            new = self.run("git rev-list -1 --before='{}' {}".format(dt_new, branch)).strip()
+            new = run("git rev-list -1 --before='{}' {}".format(dt_new, branch)).strip()
         except:
             pass
 
         # Checkout to previous version and get services
-        self.run("git checkout {}".format(old))
+        run("git checkout {}".format(old))
         previous, _ = self.parent.load_services()
 
-        self.run("git checkout {}".format(new))
+        run("git checkout {}".format(new))
         now, _ = self.parent.load_services()
 
         # Go back to where we were
-        self.run("git checkout {}".format(branch))
+        run("git checkout {}".format(branch))
 
-        changed = self.diff(now, previous)
-        logger.info("{} services changed".format(len(changed)))
+        self.fetch_diff(now, previous)
+
+        logger.info("{} services changed".format(len(self.changed_services)))
 
         # Fetch all the services that changed
-        for service in changed:
+        for service in self.changed_services:
+            # only need to checkout the first
             self.checkout(service)
 
-        # Changelog for each service as `(service, timestamp, messages)` tuple
-        changelog = []
-        for service in changed:
-            changelog.append((
-                service,
-                self.last_changed(service, service['new']),
-                self.log(service, service['old'], service['new'])
-            ))
+        url = run("git remote get-url origin").rstrip("/").rstrip(".git")
 
-        url = self.run("git remote get-url origin")
+        render = ChangelogRender(self, old, new, url)
 
-        markdown = self.markdown(changelog, old, new, url)
-
-        print(markdown)
+        print render.markdown()
 
         return 0

--- a/saasherder/changelog.py
+++ b/saasherder/changelog.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from subprocess import Popen, PIPE
+from dateutil.parser import parse
 import logging
 import os
-
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -164,6 +164,20 @@ class Changelog(object):
             branch = self.run("git rev-parse --short HEAD").strip()
             logger.info("HEAD at {} before generating changelog"
                         .format(branch))
+
+        # Resolve commit if a date was passed in 'old'
+        try:
+            dt_old = parse(old)
+            old = self.run("git rev-list -1 --before='{}' {}".format(dt_old, branch)).strip()
+        except:
+            pass
+
+        # Resolve commit if a date was passed in 'new'
+        try:
+            dt_new = parse(new)
+            new = self.run("git rev-list -1 --before='{}' {}".format(dt_new, branch)).strip()
+        except:
+            pass
 
         # Checkout to previous version and get services
         self.run("git checkout {}".format(old))

--- a/saasherder/changelog.py
+++ b/saasherder/changelog.py
@@ -41,7 +41,7 @@ class Changelog(object):
                 # or if 'hash' is not defined for either service
                 continue
 
-            if prev_service_hash != service_hash:
+            if service_hash and prev_service_hash and prev_service_hash != service_hash:
                 changed.append(
                     dict(
                         name=service['name'],

--- a/saasherder/changelog.py
+++ b/saasherder/changelog.py
@@ -2,12 +2,12 @@
 
 from subprocess import Popen, PIPE
 from dateutil.parser import parse
+
 import logging
 import os
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
 
 class Changelog(object):
 
@@ -83,10 +83,12 @@ class Changelog(object):
 
         return self.run(cmd)
 
-    def checkout(self, service, version):
+    def checkout(self, service):
         """Get a service checked out at specified version"""
 
         name = service['name']
+        version = service['new']
+
         if os.path.exists(self.worktree(name)):
             logger.info("Found git worktree for {}; updating".format(name))
             self._fetch(service)
@@ -194,7 +196,7 @@ class Changelog(object):
 
         # Fetch all the services that changed
         for service in changed:
-            self.checkout(service, service['new'])
+            self.checkout(service)
 
         # Changelog for each service as `(service, timestamp, messages)` tuple
         changelog = [(service,

--- a/saasherder/cli.py
+++ b/saasherder/cli.py
@@ -60,6 +60,7 @@ def main():
 
     subparser_changelog = subparsers.add_parser("changelog")
     subparser_changelog.add_argument("--context", action="store")
+    subparser_changelog.add_argument("--format", choices=['markdown', 'plain'], default='plain')
     subparser_changelog.add_argument("old", action="store", help="Commit or a date (parsed by dateutil.parser)")
     subparser_changelog.add_argument("new", action="store", help="Commit or a date (parsed by dateutil.parser)")
 
@@ -82,7 +83,7 @@ def main():
       if args.type == "get-contexts":
         sc.print_contexts()
     elif args.command == "changelog":
-        se.changelog.generate(args.context, args.old, args.new)
+        se.changelog.generate(args.context, args.old, args.new, args.format)
 
 if __name__ == "__main__":
   main()

--- a/saasherder/cli.py
+++ b/saasherder/cli.py
@@ -44,7 +44,7 @@ def main():
     subparser_template.add_argument("type", choices=["tag"],
                                     help="Update image tag with commit hash")
     subparser_template.add_argument("services", nargs="*", default="all",
-                                    help="Service which template should be updated")      
+                                    help="Service which template should be updated")
 
     subparser_template = subparsers.add_parser("get")
     #subparser_template.add_argument('--all', default=False, action='store_true',
@@ -60,8 +60,8 @@ def main():
 
     subparser_changelog = subparsers.add_parser("changelog")
     subparser_changelog.add_argument("--context", action="store")
-    subparser_changelog.add_argument("old", action="store")
-    subparser_changelog.add_argument("new", action="store")
+    subparser_changelog.add_argument("old", action="store", help="Commit or a date (parsed by dateutil.parser)")
+    subparser_changelog.add_argument("new", action="store", help="Commit or a date (parsed by dateutil.parser)")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR aims to fix several issues that were present:

* Refactor to separate rendering from rest of code
* Services are grouped by url and they're only checked out once
* Add multiple output formats
* Fix problem with services that have 'none' as hash
* Improve efficiency by eliminating redundant actions
* General readability issues
* Fetch repository url to be displayed in report