### PR TITLE
Do not hardcode the oc version

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,6 @@ This snippet will ensure your new service will skip deployment to production, bu
 
 ## Test
 
-NOTE: Due to an upstream issue, the tests now require a specific version of the
-`origin-clients` package. This may be reversed in the future.
-
 SaaS Herder tests are run in an isolated container, but talks to the host docker
 daemon to talk to the oc cluster.
 

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -2,7 +2,7 @@ FROM centos
 
 RUN yum -y install epel-release centos-release-openshift-origin && \
     yum -y install python-pip git && \
-    yum -y install origin-clients-3.7.0-1.0.7ed6862 && \
+    yum -y install origin-clients && \
     pip install pytest
 
 WORKDIR /opt/saasherder


### PR DESCRIPTION
Since the upstream issue referenced by #55 has been fixed we can revert
to using the default origin-clients package.