### PR TITLE
Fix #65: Add ignore-unknown-parameters

### DIFF
--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -303,7 +303,7 @@ class SaasHerder(object):
             params_processed = ["%s=%s" % (i["name"], i["value"]) for i in parameters]
             local_opt = "--local" if local else ""
 
-            cmd = ["oc", "process", local_opt, "--output", "yaml", "-f", template_file]
+            cmd = ["oc", "process", "--ignore-unknown-parameters=true", local_opt, "--output", "yaml", "-f", template_file]
             process_cmd = cmd + params_processed
 
             output_file = os.path.join(output_dir, "%s.yaml" % s["name"])
@@ -311,8 +311,10 @@ class SaasHerder(object):
             logger.info("%s > %s" % (" ".join(process_cmd), output_file))
             try:
                 output = subprocess.check_output(process_cmd)
+
                 if template_filter:
                     output = self.apply_filter(template_filter, output)
+
                 with open(output_file, "w") as fp:
                     fp.write(output)
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
From `man oc-process`

    --ignore-unknown-parameters=false
          If true, will not stop processing if a provided
          parameter does not exist in the template.