### PR TITLE
Use skopeo to check image presence

### DIFF
--- a/check_image.py
+++ b/check_image.py
@@ -1,43 +1,33 @@
-import anymarkup
+"""
+Checks the existence of a tag in a registry by calling skopeo
+"""
+
 import sys
-import requests
+import os
+import subprocess
+
+import anymarkup
 
 if len(sys.argv) < 2:
-  print("Provide path to the processed OpenShift template")
-  sys.exit(1)
-f = sys.argv[1]
+    print "Provide path to the processed OpenShift template"
+    sys.exit(1)
+
+OPENSHIFT_TEMPLATE = sys.argv[1]
+AUTH_FILE = os.path.expanduser('~/skopeo.json')
 
 images = []
-for i in anymarkup.parse_file(f)["items"]:
-  if i["kind"] == "DeploymentConfig":
-    for c in i["spec"]["template"]["spec"]["containers"]:
-      images.append(c["image"])
+for i in anymarkup.parse_file(OPENSHIFT_TEMPLATE)["items"]:
+    if i["kind"] == "DeploymentConfig":
+        for c in i["spec"]["template"]["spec"]["containers"]:
+            images.append(c["image"])
 
-for i in images:
-  image_split = i.split("/")
+for image in images:
+    with open(os.devnull, 'w') as devnull:
+        status_code = subprocess.call(
+            ['skopeo', 'inspect', '--authfile', AUTH_FILE, 'docker://%s' % (image,)], stdout=devnull)
 
-  if len(image_split) < 3:
-    print("WARNING: Registry for image %s is not set, assuming docker.io. Cannot verify image existance there. Skipping." % i)
-    continue
-
-  registry = image_split[0]
-  repo = '/'.join(image_split[1:-1])
-  name = image_split[-1]
-
-  image, tag = name.split(":")
-
-  if not registry.startswith("http"):
-    registry = "https://%s" % registry
-
-  url = "%s/v2/%s/%s/tags/list" % (registry, repo, image)
-  print("Checking %s" % url)
-
-  r = requests.get(url)
-
-  if r.status_code != 200:
-    raise Exception("Got %d from %s" % (r.status_code, url))
-
-  if tag in r.json()["tags"]:
-    print("OK")
-  else:
-    raise Exception("Could not find tag %s in registry" % tag)
+    if status_code == 0:
+        print "OK"
+    else:
+        print >>sys.stderr, "Could not find image %s in registry" % (image,)
+        sys.exit(1)


### PR DESCRIPTION
The `promote-to-prod` jobs in the Devtools space, for example [1] or [2], check the existence of the container images in the remote docker registries. The script that is ultimately reponsible of performing this check is is check_image.py [3]. 

Currently this script uses the http REST API to check that a specific image and tag is available. However, we are now moving to an authenticated registry (quay.io), and implementing this logic is cumbersome. We intend to call skopeo from within this script.

The new `check_image.py` calls the command:

    skopeo inspect docker://<registry>/<repository>/<image>:<tag>

And verifies the exit status.

[1]: https://ci.centos.org/view/Devtools/job/devtools-saas-analytics-promote-to-prod/
[2]: https://ci.centos.org/view/Devtools/job/devtools-saas-analytics-promote-to-prod-test/
[3]: https://github.com/openshiftio/saasherder/blob/master/check_image.py
