### PR TITLE
Install specifict oc version, because latest fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ test: build-test-container
 .PHONY: local-test
 local-test: build-test-container
 	docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock \
-        -v $PWD/tests:/opt/saasherder/tests \
-	    -v $PWD/saasherder:/opt/saasherder/saasherder \
+        -v $(pwd)/tests:/opt/saasherder/tests \
+	    -v $(pwd)/saasherder:/opt/saasherder/saasherder \
 	    --privileged --net=host saasherder-test

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -2,7 +2,7 @@ FROM centos
 
 RUN yum -y install epel-release centos-release-openshift-origin && \
     yum -y install python-pip git && \
-    yum -y install origin-clients && \
+    yum -y install origin-clients-3.9.0-1.el7.git.0.ba7faec && \
     pip install pytest
 
 WORKDIR /opt/saasherder


### PR DESCRIPTION
latest oc version fails, so for now we will use 3.9 version for tests