### PR TITLE
Use IMAGE_TAG if defined

### DIFF
--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -295,8 +295,12 @@ class SaasHerder(object):
                 hash_len = s.get("hash_length", self._default_hash_length)
                 tag = s["hash"][:hash_len]
 
-            parameters = [{"name": "IMAGE_TAG", "value": tag}]
             service_params = s.get("parameters", {})
+
+            if 'IMAGE_TAG' not in service_params:
+                parameters = [{"name": "IMAGE_TAG", "value": tag}]
+            else:
+                parameters = []
 
             for key, val in service_params.iteritems():
                 parameters.append({"name": key, "value": val})


### PR DESCRIPTION
In some use cases, such as deploying operators, the `IMAGE_TAG` should not be
generated from the git commit, but rather it should be hardcoded.

This PR adds the functionality of being able to define `IMAGE_TAG` in the
parameters, which will disable the dynamic generation of `IMAGE_TAG` based off the
git commit.

I have checked that `IMAGE_TAG` is not currently defined in any service in any
of the following repos, therefore after merging this PR current services will
continue working as is.

Repos checked:

- https://github.com/openshiftio/saas-analytics
- https://github.com/openshiftio/saas-chat
- https://github.com/openshiftio/saas-errortracking
- https://github.com/openshiftio/saas-launchpad
- https://github.com/openshiftio/saas-openshiftio
- https://github.com/app-sre/saas-telemeter

