### PR TITLE
Explicitely ignore hash updates when hash: ignore

### DIFF
--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -284,8 +284,12 @@ class SaasHerder(object):
             raise Exception("Expecting only one service")
 
         service = services[0]
+
         if service[cmd_type] == value:
             logger.warning("Skipping update of %s, no change" % service)
+            return
+        elif cmd_type == "hash" and service[cmd_type] == "ignore":
+            logger.warning("Skipping update of %s, no change (hash: ignore)." % service)
             return
         else:
             service[cmd_type] = value


### PR DESCRIPTION
Functionally this doesn't modify the current behaviour, but the code is
more explicit about how it's handling `hash: ignore` when doing `update
hash`.