### PR TITLE
Check image in all resource types

### DIFF
--- a/check_image.py
+++ b/check_image.py
@@ -9,7 +9,6 @@ If regex is supplied the path of the image must match this regex
 import os
 import re
 import subprocess
-
 import sys
 
 import anymarkup
@@ -52,9 +51,11 @@ except IndexError:
 
 images = []
 for i in anymarkup.parse_file(OPENSHIFT_TEMPLATE)["items"]:
-    if i["kind"] in ["DeploymentConfig", "StatefulSet"]:
+    try:
         for c in i["spec"]["template"]["spec"]["containers"]:
             images.append(c["image"])
+    except KeyError:
+        pass
 
 success = True
 

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -3,6 +3,7 @@ FROM centos
 RUN yum -y install epel-release centos-release-openshift-origin && \
     yum -y install python-pip git && \
     yum -y install origin-clients-3.9.0-1.el7.git.0.ba7faec && \
+    pip install more-itertools==4.3.0 && \
     pip install pytest==3.9.2
 
 WORKDIR /opt/saasherder

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -3,7 +3,7 @@ FROM centos
 RUN yum -y install epel-release centos-release-openshift-origin && \
     yum -y install python-pip git && \
     yum -y install origin-clients-3.9.0-1.el7.git.0.ba7faec && \
-    pip install pytest
+    pip install pytest==3.9.2
 
 WORKDIR /opt/saasherder
 


### PR DESCRIPTION
This will silently skip k8s resources that don't have
`["spec"]["template"]["spec"]["containers"]` attribute.