### PR TITLE
saasherder annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build
 dist
 saasherder.egg-info
+venv

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build push build-test-container test local-test clean
+.PHONY: build push rc build-test-container test local-test clean
 
 REGISTRY := quay.io
 IMAGE_NAME := ${REGISTRY}/openshiftio/saasherder
@@ -13,6 +13,10 @@ push:
 
 build-test-container:
 	docker build -t saasherder-test -f tests/Dockerfile.test .
+
+rc:
+	docker build --no-cache -t $(IMAGE_NAME):$(IMAGE_TAG)-rc .
+	docker push $(IMAGE_NAME):$(IMAGE_TAG)-rc
 
 test: build-test-container
 	docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock \

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -134,9 +134,8 @@ class SaasHerder(object):
         if data_obj.get("items"):
             for obj in data_obj.get("items"):
                 obj['metadata'].setdefault('annotations', {})
-                annotations = body['metadata']['annotations']
-                annotations['saasherder.service'] = \
-                    self.config.current() + '/' + service_name
+                annotations = obj['metadata']['annotations']
+                annotations['saasherder.service'] =  "%s/%s" % (self.config.current(), service_name)
 
         return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
 

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -129,6 +129,17 @@ class SaasHerder(object):
 
         return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
 
+    def apply_saasherder_annotations(self, data, service_name):
+        data_obj = yaml.safe_load(data)
+        if data_obj.get("items"):
+            for obj in data_obj.get("items"):
+                obj['metadata'].setdefault('annotations', {})
+                annotations = body['metadata']['annotations']
+                annotations['saasherder.service'] = \
+                    self.config.current() + '/' + service_name
+
+        return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
+
     def write_service_file(self, name, output=None):
         """ Writes service file to disk, either to original file name, or to a name
             given by output param """
@@ -357,6 +368,7 @@ class SaasHerder(object):
 
                 if template_filter:
                     output = self.apply_filter(template_filter, output)
+                output = self.apply_saasherder_annotations(output, s['name'])
 
                 with open(output_file, "w") as fp:
                     fp.write(output)

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -135,9 +135,9 @@ class SaasHerder(object):
             for obj in data_obj.get("items"):
                 obj['metadata'].setdefault('annotations', {})
                 annotations = obj['metadata']['annotations']
-                annotations['saasherder.service'] =  "%s/%s" % (self.config.current(), service_name)
+                annotations['saasherder.service'] = "%s/%s" % (self.config.current(), service_name)
 
-        return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
+        return yaml.safe_dump(data_obj, encoding='utf-8', default_flow_style=False)
 
     def write_service_file(self, name, output=None):
         """ Writes service file to disk, either to original file name, or to a name

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -131,11 +131,10 @@ class SaasHerder(object):
 
     def apply_saasherder_annotations(self, data, service_name):
         data_obj = yaml.safe_load(data)
-        if data_obj.get("items"):
-            for obj in data_obj.get("items"):
-                obj['metadata'].setdefault('annotations', {})
-                annotations = obj['metadata']['annotations']
-                annotations['saasherder.service'] = "%s/%s" % (self.config.current(), service_name)
+        for obj in data_obj.get("items", []):
+            obj['metadata'].setdefault('annotations', {})
+            annotations = obj['metadata']['annotations']
+            annotations['saasherder.service'] = "%s/%s" % (self.config.current(), service_name)
 
         return yaml.safe_dump(data_obj, encoding='utf-8', default_flow_style=False)
 
@@ -316,7 +315,7 @@ class SaasHerder(object):
 
         self.write_service_file(service_name, output_file)
 
-    def process_image_tag(self, services, output_dir, template_filter=None, force=False, local=False):
+    def process_image_tag(self, services, output_dir, template_filter=None, force=False, local=False, annotate=True):
         """ iterates through the services and runs oc process to generate the templates """
 
         if not find_executable("oc"):
@@ -367,7 +366,9 @@ class SaasHerder(object):
 
                 if template_filter:
                     output = self.apply_filter(template_filter, output)
-                output = self.apply_saasherder_annotations(output, s['name'])
+
+                if annotate:
+                    output = self.apply_saasherder_annotations(output, s['name'])
 
                 with open(output_file, "w") as fp:
                     fp.write(output)
@@ -376,7 +377,7 @@ class SaasHerder(object):
                 print e.message
                 sys.exit(1)
 
-    def template(self, cmd_type, services, output_dir=None, template_filter=None, force=False, local=False):
+    def template(self, cmd_type, services, output_dir=None, template_filter=None, force=False, local=False, annotate=True):
         """ Process templates """
         if not output_dir:
             output_dir = self.output_dir
@@ -385,7 +386,7 @@ class SaasHerder(object):
             os.mkdir(output_dir) #FIXME
 
         if cmd_type == "tag":
-            self.process_image_tag(services, output_dir, template_filter, force, local)
+            self.process_image_tag(services, output_dir, template_filter, force, local, annotate)
 
     def get(self, cmd_type, services):
         """ Get information about services printed to stdout """

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -108,7 +108,7 @@ class TestTemplating(object):
   def test_template_processed_files(self):
     output_dir = tempfile.mkdtemp()
     se = SaasHerder(temp_path, None)
-    se.template("tag", "all", output_dir, local=True, template_filter=["Route"])
+    se.template("tag", "all", output_dir, local=True, template_filter=["Route"], annotate=False)
 
     for root, _, files in os.walk(output_dir):
       for f in files:


### PR DESCRIPTION
this PR makes saasherder add `saasherder.service` annotation to each resource it templates.
this allows for better traceability as to what was deployed from where.