### PR TITLE
saasherder add labels and annotations

### DIFF
--- a/saasherder/cli.py
+++ b/saasherder/cli.py
@@ -53,12 +53,23 @@ def main():
                         help='Use --local option for oc process - processing happen locally instead on server')
     subparser_template.add_argument('--output-dir', default=None,
                         help='Output directory where the updated templates will be stored')
-    subparser_template.add_argument('--saas-repo-url', default=None,
-                        help='URL of saas repository (used for resource labeling)')
     subparser_template.add_argument('--filter', default=None,
                         help='Comma separated list of kinds you want to filter out')
     subparser_template.add_argument("type", choices=["tag"],
                                     help="Update image tag with commit hash")
+    subparser_template.add_argument("services", nargs="*", default="all",
+                                    help="Service which template should be updated")
+
+    # subcommand: label
+    subparser_template = subparsers.add_parser("label",
+                                                help="Add labels to a service template")
+
+    subparser_template.add_argument('--annotate', default=False, action='store_true',
+                        help='Use --annotate option to add human readable annotations where required')
+    subparser_template.add_argument('--output-dir', default=None,
+                        help='Output directory where the updated templates will be stored')
+    subparser_template.add_argument('--saas-repo-url', default=None,
+                        help='URL of saas repository (used for resource labeling)')
     subparser_template.add_argument("services", nargs="*", default="all",
                                     help="Service which template should be updated")
 
@@ -107,8 +118,10 @@ def main():
     elif args.command == "template":
         filters = args.filter.split(",") if args.filter else None
         se.template(args.type, args.services, args.output_dir, filters,
-                    force=args.force, local=args.local,
-                    saas_repo_url=args.saas_repo_url)
+                    force=args.force, local=args.local)
+    elif args.command == "label":
+        se.label(args.type, args.services, args.output_dir,
+                    saas_repo_url=args.saas_repo_url, annotate=args.annotate)
 
     elif args.command == "get":
         for val in se.get(args.type, args.services):

--- a/saasherder/cli.py
+++ b/saasherder/cli.py
@@ -53,6 +53,8 @@ def main():
                         help='Use --local option for oc process - processing happen locally instead on server')
     subparser_template.add_argument('--output-dir', default=None,
                         help='Output directory where the updated templates will be stored')
+    subparser_template.add_argument('--saas-repo-url', default=None,
+                        help='URL of saas repository (used for resource labeling)')
     subparser_template.add_argument('--filter', default=None,
                         help='Comma separated list of kinds you want to filter out')
     subparser_template.add_argument("type", choices=["tag"],
@@ -104,7 +106,9 @@ def main():
         se.update(args.type, args.service, args.value, output_file=args.output_file, verify_ssl=verify_ssl)
     elif args.command == "template":
         filters = args.filter.split(",") if args.filter else None
-        se.template(args.type, args.services, args.output_dir, filters, force=args.force, local=args.local)
+        se.template(args.type, args.services, args.output_dir, filters,
+                    force=args.force, local=args.local,
+                    saas_repo_url=args.saas_repo_url)
 
     elif args.command == "get":
         for val in se.get(args.type, args.services):

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -153,8 +153,8 @@ class SaasHerder(object):
                     "%s, saasherder.saas-repo-url-sha256sum in (%s)" \
                     % (labels_selector, saas_repo_url_hash)
                 # add annotation for human readability
-                labels = obj['metadata']['annotations']
                 obj['metadata'].setdefault('annotations', {})
+                annotations = obj['metadata']['annotations']
                 annotations['saasherder.saas-repo-url'] = saas_repo_url
 
         return yaml.safe_dump(data_obj, encoding='utf-8', default_flow_style=False), labels_selector

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -129,12 +129,12 @@ class SaasHerder(object):
 
         return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
 
-    def apply_saasherder_annotations(self, data, service_name):
+    def apply_saasherder_labels(self, data, service_name):
         data_obj = yaml.safe_load(data)
         for obj in data_obj.get("items", []):
-            obj['metadata'].setdefault('annotations', {})
-            annotations = obj['metadata']['annotations']
-            annotations['saasherder.service'] = "%s/%s" % (self.config.current(), service_name)
+            obj['metadata'].setdefault('labels', {})
+            labels = obj['metadata']['labels']
+            labels['saasherder.service'] = "%s/%s" % (self.config.current(), service_name)
 
         return yaml.safe_dump(data_obj, encoding='utf-8', default_flow_style=False)
 
@@ -315,7 +315,7 @@ class SaasHerder(object):
 
         self.write_service_file(service_name, output_file)
 
-    def process_image_tag(self, services, output_dir, template_filter=None, force=False, local=False, annotate=True):
+    def process_image_tag(self, services, output_dir, template_filter=None, force=False, local=False, label=True):
         """ iterates through the services and runs oc process to generate the templates """
 
         if not find_executable("oc"):
@@ -367,8 +367,8 @@ class SaasHerder(object):
                 if template_filter:
                     output = self.apply_filter(template_filter, output)
 
-                if annotate:
-                    output = self.apply_saasherder_annotations(output, s['name'])
+                if label:
+                    output = self.apply_saasherder_labels(output, s['name'])
 
                 with open(output_file, "w") as fp:
                     fp.write(output)
@@ -377,7 +377,7 @@ class SaasHerder(object):
                 print e.message
                 sys.exit(1)
 
-    def template(self, cmd_type, services, output_dir=None, template_filter=None, force=False, local=False, annotate=True):
+    def template(self, cmd_type, services, output_dir=None, template_filter=None, force=False, local=False, label=True):
         """ Process templates """
         if not output_dir:
             output_dir = self.output_dir
@@ -386,7 +386,7 @@ class SaasHerder(object):
             os.mkdir(output_dir) #FIXME
 
         if cmd_type == "tag":
-            self.process_image_tag(services, output_dir, template_filter, force, local, annotate)
+            self.process_image_tag(services, output_dir, template_filter, force, local, label)
 
     def get(self, cmd_type, services):
         """ Get information about services printed to stdout """

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -130,7 +130,7 @@ class SaasHerder(object):
 
         return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
 
-    def apply_saasherder_labels(self, data, service_name, saas_repo_url):
+    def apply_saasherder_labels_and_annotations(self, data, service_name, saas_repo_url):
         data_obj = yaml.safe_load(data)
         data_sha256sum = self.calculate_sha256sum_label(data)
         labels_selector = 'saasherder.sha256sum notin (%s)' % data_sha256sum
@@ -152,6 +152,10 @@ class SaasHerder(object):
                 labels_selector = \
                     "%s, saasherder.saas-repo-url-hash in (%s)" \
                     % (labels_selector, saas_repo_url_hash)
+                # add annotation for human readability
+                labels = obj['metadata']['annotations']
+                obj['metadata'].setdefault('annotations', {})
+                annotations['saasherder.saas-repo-url'] = saas_repo_url
 
         return yaml.safe_dump(data_obj, encoding='utf-8', default_flow_style=False), labels_selector
 
@@ -390,7 +394,7 @@ class SaasHerder(object):
                     output = self.apply_filter(template_filter, output)
                     
                     if label:
-                        output, labels_selector = self.apply_saasherder_labels(output, s['name'], saas_repo_url)
+                        output, labels_selector = self.apply_saasherder_labels_and_annotations(output, s['name'], saas_repo_url)
                         output_labels_file = os.path.join(output_dir, "%s-labels" % s["name"])
                         with open(output_labels_file, "w") as fp:
                             fp.write(labels_selector)

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -354,7 +354,7 @@ class SaasHerder(object):
 
         self.write_service_file(service_name, output_file)
 
-    def process_image_tag(self, services, output_dir, template_filter=None, force=False, local=False, label=True, saas_repo_url=None):
+    def process_image_tag(self, services, output_dir, template_filter=None, force=False, local=False, saas_repo_url=None):
         """ iterates through the services and runs oc process to generate the templates """
 
         if not find_executable("oc"):
@@ -404,8 +404,7 @@ class SaasHerder(object):
                 output = subprocess.check_output(process_cmd)
                 if template_filter:
                     output = self.apply_filter(template_filter, output)
-                if label:
-                    output = self.apply_saasherder_labels_and_annotations(output, s, saas_repo_url)
+                output = self.apply_saasherder_labels_and_annotations(output, s, saas_repo_url)
                 with open(output_file, "w") as fp:
                     fp.write(output)
 
@@ -414,7 +413,7 @@ class SaasHerder(object):
                 sys.exit(1)
 
     def template(self, cmd_type, services, output_dir=None, template_filter=None,
-                 force=False, local=False, label=True, saas_repo_url=None):
+                 force=False, local=False, saas_repo_url=None):
         """ Process templates """
         if not output_dir:
             output_dir = self.output_dir
@@ -423,7 +422,7 @@ class SaasHerder(object):
             os.mkdir(output_dir) #FIXME
 
         if cmd_type == "tag":
-            self.process_image_tag(services, output_dir, template_filter, force, local, label, saas_repo_url)
+            self.process_image_tag(services, output_dir, template_filter, force, local, saas_repo_url)
 
     def get(self, cmd_type, services):
         """ Get information about services printed to stdout """

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -138,7 +138,7 @@ class SaasHerder(object):
             labels = obj['metadata']['labels']
             labels['saasherder.context'] = self.config.current()
             labels['saasherder.service'] = service_name
-            labels['saasherder.sha256sum'] = data_sha256sum
+            labels['saasherder.sha256sum'] = data_sha256sum[:63]
 
         return yaml.safe_dump(data_obj, encoding='utf-8', default_flow_style=False)
 

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -5,6 +5,7 @@ import requests
 import copy
 import subprocess
 import sys
+import datetime
 import hashlib
 from distutils.spawn import find_executable
 from shutil import copyfile
@@ -131,6 +132,7 @@ class SaasHerder(object):
         return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
 
     def apply_saasherder_labels(self, data, service_name):
+        now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
         data_obj = yaml.safe_load(data)
         data_sha256sum = self.calculate_sha256sum(data)
         for obj in data_obj.get("items", []):
@@ -139,6 +141,7 @@ class SaasHerder(object):
             labels['saasherder.context'] = self.config.current()
             labels['saasherder.service'] = service_name
             labels['saasherder.sha256sum'] = data_sha256sum[:63]
+            labels['saasherder.update'] = now
 
         return yaml.safe_dump(data_obj, encoding='utf-8', default_flow_style=False)
 

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -141,7 +141,6 @@ class SaasHerder(object):
             labels['saasherder.context'] = self.config.current()
             labels['saasherder.service'] = service_name
             labels['saasherder.sha256sum'] = data_sha256sum[:63]
-            labels['saasherder.update'] = now
             labels_selector = 'saasherder.context in (%s), saasherder.service in (%s), saasherder.sha256sum notin (%s)' \
                 % (self.config.current(), service_name, data_sha256sum[:63])
 

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -406,8 +406,10 @@ class SaasHerder(object):
 
             try:
                 output = subprocess.check_output(process_cmd)
-                output = self.apply_filter(template_filter, output) if template_filter
-                output = self.apply_saasherder_labels_and_annotations(output, s, saas_repo_url) if label
+                if template_filter:
+                    output = self.apply_filter(template_filter, output)
+                if label:
+                    output = self.apply_saasherder_labels_and_annotations(output, s, saas_repo_url)
                 with open(output_file, "w") as fp:
                     fp.write(output)
 

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -384,12 +384,12 @@ class SaasHerder(object):
             process_cmd = cmd + params_processed
 
             output_file = os.path.join(output_dir, "%s.yaml" % s["name"])
-            
+
             logger.info("%s > %s" % (" ".join(process_cmd), output_file))
-            
+
             try:
                 output = subprocess.check_output(process_cmd)
-                
+
                 if template_filter:
                     output = self.apply_filter(template_filter, output)
                     

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -133,7 +133,7 @@ class SaasHerder(object):
     def apply_saasherder_labels_and_annotations(self, data, service_name, saas_repo_url):
         data_obj = yaml.safe_load(data)
         data_sha256sum = self.calculate_sha256sum_label(data)
-        labels_selector = 'saasherder.sha256sum notin (%s)' % data_sha256sum
+        labels_selector = 'saasherder.data-sha256sum notin (%s)' % data_sha256sum
         if saas_repo_url:
             saas_repo_url_hash = self.calculate_sha256sum_label(saas_repo_url)
         
@@ -142,15 +142,15 @@ class SaasHerder(object):
             labels = obj['metadata']['labels']
             labels['saasherder.context'] = self.config.current()
             labels['saasherder.service'] = service_name
-            labels['saasherder.sha256sum'] = data_sha256sum[:63]
+            labels['saasherder.data-sha256sum'] = data_sha256sum[:63]
             labels_selector = \
                 '%s, saasherder.context in (%s), saasherder.service in (%s)' \
                 % (labels_selector, self.config.current(), service_name)
 
             if saas_repo_url:
-                labels['saasherder.saas-repo-url-hash'] = saas_repo_url_hash
+                labels['saasherder.saas-repo-url-sha256sum'] = saas_repo_url_hash
                 labels_selector = \
-                    "%s, saasherder.saas-repo-url-hash in (%s)" \
+                    "%s, saasherder.saas-repo-url-sha256sum in (%s)" \
                     % (labels_selector, saas_repo_url_hash)
                 # add annotation for human readability
                 labels = obj['metadata']['annotations']

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -136,10 +136,6 @@ class SaasHerder(object):
 
         saasherder_labels = \
             self.get_saasherder_labels(data, service, saas_repo_url)
-
-        data_sha256sum = sha256sum_short(data)
-        if saas_repo_url:
-            saas_repo_url_sha256sum = sha256sum_short(saas_repo_url)
         
         for obj in data_obj.get("items", []):
             # add labels for label selector filtering
@@ -158,13 +154,13 @@ class SaasHerder(object):
 
     @staticmethod
     def sha256sum_short(data):
-        return hashlib.sha256().update(data)[:10]
+        return hashlib.sha256(data).hexdigest()[:10]
 
     def get_saasherder_labels(self, data, service, saas_repo_url):
         labels = {}
-        labels['saasherder.data-sha256sum'] = sha256sum_short(data)
+        labels['saasherder.data-sha256sum'] = self.sha256sum_short(data)
         labels['saasherder.saas-repo-url-sha256sum'] = \
-            sha256sum_short(saas_repo_url) if saas_repo_url else ''
+            self.sha256sum_short(saas_repo_url) if saas_repo_url else ''
         labels['saasherder.context'] = self.config.current()
         labels['saasherder.service'] = service['name']
 

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -5,7 +5,6 @@ import requests
 import copy
 import subprocess
 import sys
-import datetime
 import hashlib
 from distutils.spawn import find_executable
 from shutil import copyfile
@@ -132,7 +131,6 @@ class SaasHerder(object):
         return yaml.dump(data_obj, encoding='utf-8', default_flow_style=False)
 
     def apply_saasherder_labels(self, data, service_name, saas_repo_url):
-        now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
         data_obj = yaml.safe_load(data)
         data_sha256sum = self.calculate_sha256sum(data)
         for obj in data_obj.get("items", []):

--- a/tests/data/fixtures/hash_length.yaml
+++ b/tests/data/fixtures/hash_length.yaml
@@ -3,10 +3,16 @@ items:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
     generation: 1
     labels:
       run: redirector
+      saasherder.context: saas
+      saasherder.data-sha256sum: 595feb9b05
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: hash_length
     name: redirector
   spec:
     replicas: '100'
@@ -57,7 +63,14 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
+    labels:
+      saasherder.context: saas
+      saasherder.data-sha256sum: 595feb9b05
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: hash_length
     name: redirector
   spec:
     ports:

--- a/tests/data/fixtures/multiple_services.yaml
+++ b/tests/data/fixtures/multiple_services.yaml
@@ -3,10 +3,16 @@ items:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
     generation: 1
     labels:
       run: redirector
+      saasherder.context: saas
+      saasherder.data-sha256sum: ab0d2547fe
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: multiple_services
     name: redirector
   spec:
     replicas: '100'
@@ -57,7 +63,14 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
+    labels:
+      saasherder.context: saas
+      saasherder.data-sha256sum: ab0d2547fe
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: multiple_services
     name: redirector
   spec:
     ports:

--- a/tests/data/fixtures/redirector-ignore.yaml
+++ b/tests/data/fixtures/redirector-ignore.yaml
@@ -3,10 +3,16 @@ items:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
     generation: 1
     labels:
       run: redirector
+      saasherder.context: saas
+      saasherder.data-sha256sum: d5fd493a0b
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: redirector-ignore
     name: redirector
   spec:
     replicas: 1
@@ -63,7 +69,14 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
+    labels:
+      saasherder.context: saas
+      saasherder.data-sha256sum: d5fd493a0b
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: redirector-ignore
     name: redirector
   spec:
     ports:

--- a/tests/data/fixtures/redirector.yaml
+++ b/tests/data/fixtures/redirector.yaml
@@ -3,10 +3,16 @@ items:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
     generation: 1
     labels:
       run: redirector
+      saasherder.context: saas
+      saasherder.data-sha256sum: 21281f3747
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: redirector
     name: redirector
   spec:
     replicas: 1
@@ -57,7 +63,14 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    annotations:
+      saasherder.saas-repo-url: ''
     creationTimestamp: null
+    labels:
+      saasherder.context: saas
+      saasherder.data-sha256sum: 21281f3747
+      saasherder.saas-repo-url-sha256sum: ''
+      saasherder.service: redirector
     name: redirector
   spec:
     ports:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -108,7 +108,7 @@ class TestTemplating(object):
   def test_template_processed_files(self):
     output_dir = tempfile.mkdtemp()
     se = SaasHerder(temp_path, None)
-    se.template("tag", "all", output_dir, local=True, template_filter=["Route"], annotate=False)
+    se.template("tag", "all", output_dir, local=True, template_filter=["Route"], label=False)
 
     for root, _, files in os.walk(output_dir):
       for f in files:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -108,18 +108,15 @@ class TestTemplating(object):
   def test_template_processed_files(self):
     output_dir = tempfile.mkdtemp()
     se = SaasHerder(temp_path, None)
-    se.template("tag", "all", output_dir, local=True, template_filter=["Route"], label=False)
+    se.template("tag", "all", output_dir, local=True, template_filter=["Route"], label=True)
 
     for root, _, files in os.walk(output_dir):
       for f in files:
         if not f.endswith("yaml"):
           continue
 
-        print(f)
-
         processed = os.path.join(root, f)
         fixture = os.path.join(fixtures_dir, f)
-
         assert filecmp.cmp(processed, fixture)
 
   def test_template_parameters(self):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -108,7 +108,7 @@ class TestTemplating(object):
   def test_template_processed_files(self):
     output_dir = tempfile.mkdtemp()
     se = SaasHerder(temp_path, None)
-    se.template("tag", "all", output_dir, local=True, template_filter=["Route"], label=True)
+    se.template("tag", "all", output_dir, local=True, template_filter=["Route"])
 
     for root, _, files in os.walk(output_dir):
       for f in files:


### PR DESCRIPTION
This PR adds labels and annotations to `saasherder template`.

The purpose is:
1. get traceability as to what is deployed from where:
   added labels:
    - `saasherder.context` - saasherder context
    - `saasherder.service` - saasherder service
    - `saasherder.data-sha256sum` - sha sum of the resources about to be deployed
    - `saasherder.saas-repo-url-sha256sum` - sha sum of the saas repo url
    added annotations:
    - `saasherder.saas-repo-url` - saas repo url in a human readable form
2. get the ability to filter resources previously deployed by the current pipeline - saasherder will write a `{service}-labels` file to the output dir with the label selector string to search for to get orphaned resources:
    - `saasherder.context` - equal to current
    - `saasherder.service` - equal to current
    - `saasherder.saas-repo-url-sha256sum` - equal to current
    - `saasherder.data-sha256sum` - different from current

by using `oc` with the output label selector string we can get a list of all orphaned resources that should be deleted.

changes to existing saasherder commands:
- `template` - added an optional `--saas-repo-url` flag.

relevant app-interface PR: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/1278

cc @jfchevrette 