### PR TITLE
Improve output when service not found in saas repo

### DIFF
--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -224,10 +224,14 @@ class SaasHerder(object):
             result = [self.services.get(s) for s in service_names if self.services.get(s)]
         else:
             # single service
-            result = [self.services.get(service_names)]
+            service = self.services.get(service_names)
+            if service:
+                result = [service]
+            else:
+                result = []
 
         if len(result) == 0:
-            logger.error("Could not find services %s" % service_names)
+            logger.error("Could not find services '%s' in the saas repo" % service_names)
 
         return result
 
@@ -280,10 +284,9 @@ class SaasHerder(object):
         """ Update service object and write it to file """
         services = self.get_services(service_name)
         if len(services) == 0:
-            raise Exception("Could not found the service")
+            raise Exception("Could not find a service called '%s' in the saas repo" % service_name)
         elif len(services) > 1:
             raise Exception("Expecting only one service")
-
         service = services[0]
 
         if service[cmd_type] == value:


### PR DESCRIPTION
Currently if saasherder is executed with a service name that doesn't exist in the saas repo, it will fail with the following trace
```
Traceback (most recent call last):
  File "/usr/bin/saasherder", line 11, in <module>
    load_entry_point('saasherder==0.1.0', 'console_scripts', 'saasherder')()
  File "build/bdist.linux-x86_64/egg/saasherder/cli.py", line 121, in main
  File "build/bdist.linux-x86_64/egg/saasherder/saasherder.py", line 289, in update
TypeError: 'NoneType' object has no attribute '__getitem__'
Build step 'Execute shell' marked build as failure
```

This is not very helpful.

This PR improves the single-service code path so that a proper error is shown. The error message is also updated to indicate what service name is not being found