### PR TITLE
[check_image.py] skopeo inspect retry

### DIFF
--- a/check_image.py
+++ b/check_image.py
@@ -68,21 +68,19 @@ for image in images:
 
     attempt = 1
     max_attemps = 5
-    attempt_success = False
-    while not attempt_success and attempt <= max_attemps:
+    while True:
         status_code, stdout, stderr = skopeo_inspect(image)
         if status_code == 0:
             print ["OK", image]
-            attempt_success = True
-            continue
+            break
 
         print >>sys.stderr, ["ERROR", image, stderr]
         if attempt < max_attemps:
             time.sleep(attempt)
-        attempt += 1
-
-    if not attempt_success:
-        success = False
+            attempt += 1
+        else:
+            success = False
+            break
 
 if not success:
     sys.exit(1)

--- a/check_image.py
+++ b/check_image.py
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 
 import anymarkup
 
@@ -22,14 +23,13 @@ SKOPEO_USER = os.environ.get('SKOPEO_USER')
 SKOPEO_PASS = os.environ.get('SKOPEO_PASS')
 
 
-def skopeo_inspect(image, auth=True):
+def skopeo_inspect(image):
     cmd = ['skopeo', 'inspect']
 
-    if auth:
-        if SKOPEO_USER and SKOPEO_PASS:
-            cmd += ['--creds', '{}:{}'.format(SKOPEO_USER, SKOPEO_PASS)]
-        else:
-            cmd += ['--authfile', AUTH_FILE]
+    if SKOPEO_USER and SKOPEO_PASS:
+        cmd += ['--creds', '{}:{}'.format(SKOPEO_USER, SKOPEO_PASS)]
+    else:
+        cmd += ['--authfile', AUTH_FILE]
 
     cmd += ['docker://{}'.format(image)]
 
@@ -62,23 +62,27 @@ success = True
 for image in images:
     if image_path_pattern and not image_path_pattern.search(image):
         print >>sys.stderr, ["ERROR_NO_MATCH",
-                             image, image_path_pattern.pattern]
+                            image, image_path_pattern.pattern]
         success = False
         continue
 
-    status_code, stdout_auth, stderr_auth = skopeo_inspect(image, True)
-    if status_code == 0:
-        print ["OK_AUTH", image]
-        continue
+    attempt = 1
+    max_attemps = 5
+    attempt_success = False
+    while not attempt_success and attempt <= max_attemps:
+        status_code, stdout, stderr = skopeo_inspect(image)
+        if status_code == 0:
+            print ["OK", image]
+            attempt_success = True
+            continue
 
-    status_code, stdout_noauth, stderr_noauth = skopeo_inspect(image, False)
-    if status_code == 0:
-        print ["OK_NOAUTH", image]
-        continue
+        print >>sys.stderr, ["ERROR", image, stderr]
+        if attempt < max_attemps:
+            time.sleep(attempt)
+        attempt += 1
 
-    print >>sys.stderr, ["ERROR_AUTH", image, stderr_auth]
-    print >>sys.stderr, ["ERROR_NOAUTH", image, stderr_noauth]
-    success = False
+    if not attempt_success:
+        success = False
 
 if not success:
     sys.exit(1)

--- a/check_image.py
+++ b/check_image.py
@@ -62,7 +62,7 @@ success = True
 for image in images:
     if image_path_pattern and not image_path_pattern.search(image):
         print >>sys.stderr, ["ERROR_NO_MATCH",
-                            image, image_path_pattern.pattern]
+                             image, image_path_pattern.pattern]
         success = False
         continue
 


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1426

This PR does:
1. simplifies the skopeo_inspect command - no use of trying once with auth and once without when we can determine that based on the skopeo environment variables.
2. adds retries to skopeo inspect to handle rate limit or any other error. currently set to 5 attempts, we can extract that to an argument later if we like.