### PR TITLE
support dictionary like objects in template

### DIFF
--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -1,15 +1,17 @@
-import os
-import anymarkup
-import yaml
-import requests
 import copy
+import hashlib
+import json
+import os
 import subprocess
 import sys
-import hashlib
 from distutils.spawn import find_executable
 from shutil import copyfile
-from config import SaasConfig
 
+import anymarkup
+import requests
+import yaml
+
+from config import SaasConfig
 from validation import VALIDATION_RULES
 
 import logging
@@ -350,6 +352,10 @@ class SaasHerder(object):
                     val = 'true'
                 elif val is False:
                     val = 'false'
+
+                if any([isinstance(val, t) for t in [dict, list, tuple]]):
+                    val = json.dumps(val)
+
                 parameters.append({"name": key, "value": val})
 
             params_processed = ["%s=%s" % (i["name"], i["value"]) for i in parameters]
@@ -391,7 +397,7 @@ class SaasHerder(object):
 
         saasherder_labels = \
             self.get_saasherder_labels(data, service, saas_repo_url)
-        
+
         for obj in data_obj.get("items", []):
             # add labels for label selector filtering
             labels = obj['metadata'].setdefault('labels', {})

--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -8,8 +8,10 @@ FROM centos:7
 RUN yum -y install epel-release centos-release-openshift-origin && \
     yum -y install python-pip git && \
     yum -y install origin-clients-3.9.0-1.el7.git.0.ba7faec && \
+    pip install -U pip && \
     pip install more-itertools==4.3.0 && \
-    pip install pytest==3.9.2
+    pip install pytest==3.9.2 && \
+    pip install zipp==1.2.0
 
 WORKDIR /opt/saasherder
 


### PR DESCRIPTION
If a parameter is a dictionary or an array, it was being incorrectly
rendered into the template.

With this patch, if a parameter is an object, it will be rendered
correctly provided that the parameter is using double curly braces:
`${{...}}`.

More info:
https://docs.openshift.com/container-platform/4.3/openshift_images/using-templates.html#templates-writing-parameters_using-templates