### PR TITLE
add support for ignore-unknown-parameters for oc process

### DIFF
--- a/saasherder/cli.py
+++ b/saasherder/cli.py
@@ -51,6 +51,8 @@ def main():
                         help='Force processing of all templates (i.e. those with skip: True)')
     subparser_template.add_argument('--local', default=False, action='store_true',
                         help='Use --local option for oc process - processing happen locally instead on server')
+    subparser_template.add_argument('--ignore-unknown-parameters', default=False, action='store_true',
+                        help='If true, will not stop processing if a provided parameter does not exist in the template.')
     subparser_template.add_argument('--output-dir', default=None,
                         help='Output directory where the updated templates will be stored')
     subparser_template.add_argument('--filter', default=None,
@@ -119,7 +121,10 @@ def main():
         se.update(args.type, args.service, args.value, output_file=args.output_file, verify_ssl=verify_ssl)
     elif args.command == "template":
         filters = args.filter.split(",") if args.filter else None
-        se.template(args.type, args.services, args.output_dir, filters, force=args.force, local=args.local)
+        se.template(args.type, args.services, args.output_dir, filters,
+                    force=args.force,
+                    local=args.local,
+                    ignore_unknown_parameters=args.ignore_unknown_parameters)
     elif args.command == "label":
         se.label(args.services, args.input_dir, args.output_dir,
                  saas_repo_url=args.saas_repo_url, current=args.current)

--- a/saasherder/saasherder.py
+++ b/saasherder/saasherder.py
@@ -312,7 +312,11 @@ class SaasHerder(object):
 
         self.write_service_file(service_name, output_file)
 
-    def process_image_tag(self, services, output_dir, template_filter=None, force=False, local=False):
+    def process_image_tag(self, services, output_dir,
+                          template_filter=None,
+                          force=False,
+                          local=False,
+                          ignore_unknown_parameters=False):
         """ iterates through the services and runs oc process to generate the templates """
 
         if not find_executable("oc"):
@@ -360,8 +364,16 @@ class SaasHerder(object):
 
             params_processed = ["%s=%s" % (i["name"], i["value"]) for i in parameters]
             local_opt = "--local" if local else ""
+            ignore_unknown_parameters_opt = \
+                "--ignore-unknown-parameters" if ignore_unknown_parameters else ""
 
-            cmd = ["oc", "process", local_opt, "--output", "yaml", "-f", template_file]
+            cmd = [
+                "oc", "process",
+                local_opt,
+                ignore_unknown_parameters_opt,
+                "--output", "yaml",
+                "-f", template_file
+            ]
             process_cmd = cmd + params_processed
 
             output_file = os.path.join(output_dir, "%s.yaml" % s["name"])
@@ -381,7 +393,12 @@ class SaasHerder(object):
                 print e.message
                 sys.exit(1)
 
-    def template(self, cmd_type, services, output_dir=None, template_filter=None, force=False, local=False):
+    def template(self, cmd_type, services,
+                 output_dir=None,
+                 template_filter=None,
+                 force=False,
+                 local=False,
+                 ignore_unknown_parameters=False):
         """ Process templates """
         if not output_dir:
             output_dir = self.output_dir
@@ -390,7 +407,12 @@ class SaasHerder(object):
             os.mkdir(output_dir) #FIXME
 
         if cmd_type == "tag":
-            self.process_image_tag(services, output_dir, template_filter, force, local)
+            self.process_image_tag(
+                services, output_dir,
+                template_filter,
+                force,
+                local,
+                ignore_unknown_parameters)
 
     def apply_saasherder_labels(self, data, service, saas_repo_url):
         data_obj = yaml.safe_load(data)


### PR DESCRIPTION
From `oc process --help`:
```
--ignore-unknown-parameters=false: If true, will not stop processing if a provided parameter
does not exist in the template.
```

We are constantly having a chicken and egg situation, which can be "solved" using this flag.